### PR TITLE
chore: avoid using deprecation annotation for Webxdc.sendUpdate

### DIFF
--- a/webxdc.d.ts
+++ b/webxdc.d.ts
@@ -117,15 +117,9 @@ export interface Webxdc<StatusPayload> {
   /**
    * Webxdc are usually shared in a chat and run independently on each peer. To get a shared status, the peers use sendUpdate() to send updates to each other.
    * @param update status update to send
+   * @param description @deprecated, pass an empty string for backward compatibility
    */
-  sendUpdate(update: SendingStatusUpdate<StatusPayload>): void;
-  /**
-   * Deprecated, use {@link Webxdc.sendUpdate | sendUpdate(update)} instead
-   * @deprecated
-   * @param update status update to send
-   * @param description Deprecated, pass an empty string for backward compatibility
-   */
-  sendUpdate(update: SendingStatusUpdate<StatusPayload>, description: string): void;
+  sendUpdate(update: SendingStatusUpdate<StatusPayload>, description: ""): void;
   /**
    * Send a message with file, text or both to a chat.
    * Asks user to what Chat to send the message to.

--- a/webxdc.d.ts
+++ b/webxdc.d.ts
@@ -117,9 +117,15 @@ export interface Webxdc<StatusPayload> {
   /**
    * Webxdc are usually shared in a chat and run independently on each peer. To get a shared status, the peers use sendUpdate() to send updates to each other.
    * @param update status update to send
-   * @param description @deprecated, pass an empty string for backward compatibility
    */
-  sendUpdate(update: SendingStatusUpdate<StatusPayload>, description: ""): void;
+  sendUpdate(update: SendingStatusUpdate<StatusPayload>): void;
+  /**
+   * Deprecated, use {@link Webxdc.sendUpdate | sendUpdate(update)} instead
+   * @deprecated
+   * @param update status update to send
+   * @param description Deprecated, pass an empty string for backward compatibility
+   */
+  sendUpdate(update: SendingStatusUpdate<StatusPayload>, description: string): void;
   /**
    * Send a message with file, text or both to a chat.
    * Asks user to what Chat to send the message to.

--- a/webxdc.d.ts
+++ b/webxdc.d.ts
@@ -117,7 +117,7 @@ export interface Webxdc<StatusPayload> {
   /**
    * Webxdc are usually shared in a chat and run independently on each peer. To get a shared status, the peers use sendUpdate() to send updates to each other.
    * @param update status update to send
-   * @param description @deprecated, pass an empty string for backward compatibility
+   * @param description Deprecated but must be an empty string for backwards compatibility
    */
   sendUpdate(update: SendingStatusUpdate<StatusPayload>, description: ""): void;
   /**


### PR DESCRIPTION
Unfortunately JSDoc/TSDoc doesn't support marking specific function parameters using `@deprecated`. The current usage of this annotation in `Webxdc.sendUpdate/2` causes the correct usage of the function to be displayed as though it's deprecated.

~This PR updates the type definition to properly mark the _signature_ as deprecated and also provide the correct signature.~ EDIT: this PR now just removes the annotation and updates the documentation for the deprecated parameter

---

Before:

- Incorrect deprecation notice of the function (not the parameter) despite correct signature:

    <img width="400" alt="image" src="https://github.com/user-attachments/assets/5c7faa47-bdb2-4fb2-9338-28e8848fc81b" />


After:

- Preferred(?) signature:

    <img width="400" alt="image" src="https://github.com/user-attachments/assets/873e44dd-efb6-4ae9-af6a-f40d6cfd1a8b" />
    
- Deprecated signature:

    <img width="400" alt="image" src="https://github.com/user-attachments/assets/6a961056-36fb-46e1-a44d-c0241b529cdb" />

    <img width="400" alt="image" src="https://github.com/user-attachments/assets/9ed1e73b-a7e3-4d8f-bd8c-182ef5f3163a" />



