### PR TITLE
Make `webxdc.setUpdateListener` API work correctly with async callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ release date when you use `npm version` (see `README.md`).
 
 ## [Unreleased]
 
+- Make `webxdc.setUpdateListener` API work correctly with async callbacks
+
 ## [2.1.2][] - 2024-11-27
 
 ### Fixed

--- a/webxdc.d.ts
+++ b/webxdc.d.ts
@@ -30,11 +30,11 @@ export type SendingStatusUpdate<PayloadType> = {
 };
 
 export type ReceivedStatusUpdate<PayloadType> = SendingStatusUpdate<PayloadType> & {
-  /** the serial number of this update. Serials are larger than 0 and newer serials have higher numbers */
-  serial: number;
-  /** the maximum serial currently known */
-  max_serial: number;
-};
+    /** the serial number of this update. Serials are larger than 0 and newer serials have higher numbers */
+    serial: number;
+    /** the maximum serial currently known */
+    max_serial: number;
+  };
 
 export type XDCFile = {
   /** name of the file, including extension */
@@ -99,8 +99,10 @@ export interface Webxdc<StatusPayload> {
    * @returns promise that resolves when the listener has processed all the update messages known at the time when {@link setUpdateListener} was called.
    * */
   setUpdateListener(
-    cb: (statusUpdate: ReceivedStatusUpdate<StatusPayload>) => void,
-    serial?: number,
+    cb: (
+      statusUpdate: ReceivedStatusUpdate<StatusPayload>
+    ) => void | Promise<void>,
+    serial?: number
   ): Promise<void>;
 
   /**


### PR DESCRIPTION
discussion started by: https://github.com/deltachat/deltachat-desktop/pull/4537

needs more PRs:
- [x] desktop (https://github.com/deltachat/deltachat-desktop/pull/4537)
- [ ] android
- [ ] iOS
- [ ] deltatouch
- [ ] cheogram
- [ ] documentation website